### PR TITLE
Adoptions-for-avi

### DIFF
--- a/.github/actions/setup-node-pnpm-install/action.yml
+++ b/.github/actions/setup-node-pnpm-install/action.yml
@@ -21,7 +21,7 @@ runs:
         run_install: false
     - uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: lts/*
         cache: 'pnpm'
 
     - name: 📦 Install Project Dependencies

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "7.0.5",
   "private": true,
   "engines": {
-    "node": ">=22.15.0"
+    "node": ">=22.14.0"
   },
   "main": "expo-router/entry",
   "scripts": {


### PR DESCRIPTION
- Downgrade min. node version to 22.14 to align with local dev-setup on macOS